### PR TITLE
Dialer: disable anti-falsing for call answer screen

### DIFF
--- a/java/com/android/incallui/answer/impl/answermethod/FlingUpDownTouchHandler.java
+++ b/java/com/android/incallui/answer/impl/answermethod/FlingUpDownTouchHandler.java
@@ -367,21 +367,6 @@ class FlingUpDownTouchHandler implements OnTouchListener {
   }
 
   private boolean isFalseTouch() {
-    if (falsingManager != null && falsingManager.isEnabled()) {
-      if (falsingManager.isFalseTouch()) {
-        if (touchUsesFalsing) {
-          LogUtil.i("FlingUpDownTouchHandler.isFalseTouch", "rejecting false touch");
-          return true;
-        } else {
-          LogUtil.i(
-              "FlingUpDownTouchHandler.isFalseTouch",
-              "Suspected false touch, but not using false touch rejection for this gesture");
-          return false;
-        }
-      } else {
-        return false;
-      }
-    }
     return !touchAboveFalsingThreshold;
   }
 


### PR DESCRIPTION
 * The anti-falsing implementation from HumanInteractionClassifier
    regularly prevents easy swipe to answer, requiring multiple
    attempts until accepted.

Change-Id: Iebad27f9da7bb8fea6fc663dc99ac6c17d94ed5f